### PR TITLE
Remove the use of innerHTML

### DIFF
--- a/src/ngx-slider/lib/slider-label.directive.ts
+++ b/src/ngx-slider/lib/slider-label.directive.ts
@@ -26,7 +26,7 @@ export class SliderLabelDirective extends SliderElementDirective {
     }
 
     this._value = value;
-    this.elemRef.nativeElement.innerHTML = value;
+    this.elemRef.nativeElement.text = value;
 
     // Update dimension only when length of the label have changed
     if (recalculateDimension) {


### PR DESCRIPTION
The slider-label makes use of element.innerHTML which means that sites that make use of a content security policy throw exceptions. This PR gets around the problem by simply using the .text property instead of .innerHTML.

There is an [open issue 324](https://github.com/angular-slider/ngx-slider/issues/324 ) on the parent project which details this well which I have simply copied here:

![image](https://user-images.githubusercontent.com/5709236/236505256-a97ce032-e70c-49ad-8b32-42987c2b4bdd.png)

Our CSP is configured as [per Angular's recommendation](https://angular.io/guide/security#enforcing-trusted-types):

`trusted-types angular angular#bundler; require-trusted-types-for 'script'; default-src 'self'; script-src 'self' 'unsafe-hashes' 'sha256-MhtPZXr7+LpJUY5qtMutB+qWfQtMaPccfe7QXtCcEYc='; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; object-src 'none'; base-uri 'self'; connect-src 'self'; font-src 'self' https://fonts.gstatic.com; frame-src 'self' ; img-src 'self' blob: data:; manifest-src 'self'; media-src 'self'; frame-ancestors 'none'; form-action 'self`

Even adding angular#unsafe-bypass as trusted-type doesn't work. This is a security concern

